### PR TITLE
Persisted coupon codes scoped by campaign

### DIFF
--- a/app/assets/stylesheets/campaigns.scss
+++ b/app/assets/stylesheets/campaigns.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the campaigns controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/campaigns.scss
+++ b/app/assets/stylesheets/campaigns.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the campaigns controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+code.redeemed {
+  text-decoration: line-through;
+}

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,89 @@
+body {
+  background-color: #fff;
+  color: #333;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+  margin: 33px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+  margin: 33px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding-bottom: 7px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px;
+  padding-bottom: 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px;
+    margin-bottom: 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,9 +1,10 @@
 class CampaignsController < ApplicationController
-  before_action :set_campaign, only: [:show]
+  before_action :set_campaign, only: [:show, :redeem_code]
 
   # GET /campaigns/1
   # GET /campaigns/1.json
   def show
+    render locals: { campaign: @campaign}
   end
 
   # POST /campaigns
@@ -22,14 +23,36 @@ class CampaignsController < ApplicationController
     end
   end
 
-  private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_campaign
-      @campaign = Campaign.find(params[:id])
+  def redeem_code
+    msg = []
+    user_code = params[:code]
+
+    code = @campaign.codes.find_by(code: user_code)
+
+    unless code
+      msg << 'Code not found.'
+    else
+      if code.redeemed?
+        msg << 'Code already redeemed.'
+      end
+
+      unless code.redeem
+        msg << 'Code redeem failed.'
+      end
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def campaign_params
-      params.require(:campaign).permit(:title)
-    end
+    msg << 'Code was successfully redeemed.' if msg.empty?
+
+    redirect_to @campaign, notice: msg.join(', ')
+  end
+
+  private
+
+  def set_campaign
+    @campaign = Campaign.find(params[:id])
+  end
+
+  def campaign_params
+    params.require(:campaign).permit(:title)
+  end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,0 +1,35 @@
+class CampaignsController < ApplicationController
+  before_action :set_campaign, only: [:show]
+
+  # GET /campaigns/1
+  # GET /campaigns/1.json
+  def show
+  end
+
+  # POST /campaigns
+  # POST /campaigns.json
+  def create
+    @campaign = Campaign.new(campaign_params)
+
+    respond_to do |format|
+      if @campaign.save
+        format.html { redirect_to @campaign, notice: 'Campaign was successfully created.' }
+        format.json { render :show, status: :created, location: @campaign }
+      else
+        format.html { render :new }
+        format.json { render json: @campaign.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_campaign
+      @campaign = Campaign.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def campaign_params
+      params.require(:campaign).permit(:title)
+    end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
-    render locals: { codes: codes }
+    render locals: { codes: codes, campaign: Campaign.new }
   end
 
   private

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,0 +1,2 @@
+class Campaign < ApplicationRecord
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,2 +1,12 @@
 class Campaign < ApplicationRecord
+  DEFAULT_MAX_CODE = 10
+
+  has_many :codes,  dependent: :delete_all
+
+  before_validation -> (r) { r.max_code ||= DEFAULT_MAX_CODE }, on: :create
+  after_create :generate_default_codes
+
+  def generate_default_codes
+    1.upto(max_code).each { codes.create! }
+  end
 end

--- a/app/models/code.rb
+++ b/app/models/code.rb
@@ -1,0 +1,15 @@
+class Code < ApplicationRecord
+  belongs_to :campaign
+  validates :code, presence: true, uniqueness: { scope: :campaign }
+  validate -> (r) { errors.add(:code, 'Code is not valid.') if CouponCode.validate(r.code).nil? }
+  before_validation -> (r) { r.code = CouponCode.generate }, on: :create
+
+  def redeem
+    return false if redeemed?
+    touch :redeemed_at
+  end
+
+  def redeemed?
+    redeemed_at?
+  end
+end

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,0 +1,8 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @campaign.title %>
+</p>
+
+<%= link_to 'Back', root_path %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,8 +1,37 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Title:</strong>
+<h1>
+  <strong>Campaign:</strong>
   <%= @campaign.title %>
-</p>
+</h1>
 
-<%= link_to 'Back', root_path %>
+<h3>Codes:</h3>
+<table class="code-list">
+  <thead>
+  <tr>
+    <th>Code</th>
+    <th>Redeem</th>
+  </tr>
+  </thead>
+  <% campaign.codes.each do |code| %>
+    <tr>
+      <td><code class="<%= 'redeemed' if code.redeemed? %>"><%= code.code %></code></td>
+      <td><%= time_ago_in_words code.redeemed_at if code.redeemed? %></td>
+    </tr>
+  <% end %>
+</table>
+
+<h3>Redeem</h3>
+
+<%= form_for(campaign, url: redeem_code_campaign_path(campaign), method: :put) do |f| %>
+  <div class="field">
+    <%= text_field_tag :code %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>
+
+
+<%= link_to 'Home', root_path %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,33 @@
 <h1>Coupon code generator</h1>
 
+<h2>1. I want to create a campaign and generate coupon codes for it.</h2>
+
+<%= form_for(campaign) do |f| %>
+  <% if campaign.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(campaign.errors.count, "error") %> prohibited this campaign from being saved:</h2>
+
+      <ul>
+        <% campaign.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>
+
+
+<h2>2. I just want one-off random coupon codes.</h2>
+
 <p>Randomly generated <%= codes.count %> codes:</p>
 
 <% codes.each do |code| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  resources :campaigns, only: [:create, :show]
+
+  resources :campaigns, only: [:create, :show, :redeem_code] do
+    put 'redeem_code', on: :member
+  end
 
   root 'home#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resources :campaigns, only: [:create, :show]
+
   root 'home#index'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20160625032216_enable_uuid_extension.rb
+++ b/db/migrate/20160625032216_enable_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidExtension < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end

--- a/db/migrate/20160625032241_create_campaigns.rb
+++ b/db/migrate/20160625032241_create_campaigns.rb
@@ -2,6 +2,7 @@ class CreateCampaigns < ActiveRecord::Migration[5.0]
   def change
     create_table :campaigns, id: :uuid do |t|
       t.string :title
+      t.integer :max_code, null: false
 
       t.timestamps
     end

--- a/db/migrate/20160625032241_create_campaigns.rb
+++ b/db/migrate/20160625032241_create_campaigns.rb
@@ -1,0 +1,9 @@
+class CreateCampaigns < ActiveRecord::Migration[5.0]
+  def change
+    create_table :campaigns, id: :uuid do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160625043908_create_codes.rb
+++ b/db/migrate/20160625043908_create_codes.rb
@@ -1,0 +1,12 @@
+class CreateCodes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :codes do |t|
+      t.references :campaign, type: :uuid
+      t.string :code, null: false
+      t.datetime :redeemed_at
+
+      t.timestamps
+    end
+    add_index :codes, [:campaign_id, :code], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20160625032241) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
+
+  create_table "campaigns", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string   "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160625032241) do
+ActiveRecord::Schema.define(version: 20160625043908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,8 +18,19 @@ ActiveRecord::Schema.define(version: 20160625032241) do
 
   create_table "campaigns", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "title"
+    t.integer  "max_code",   null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "codes", force: :cascade do |t|
+    t.uuid     "campaign_id"
+    t.string   "code",        null: false
+    t.datetime "redeemed_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["campaign_id", "code"], name: "index_codes_on_campaign_id_and_code", unique: true, using: :btree
+    t.index ["campaign_id"], name: "index_codes_on_campaign_id", using: :btree
   end
 
 end


### PR DESCRIPTION
The app only generated and display 100 randomly generated coupon codes. They are not persisted in the system and will not be accessible again once the page is unloaded.

I'd like to change this app so that the app keeps generated codes and the user can view and redeem the codes later. To do so, this PR will add concepts of campaign and code. A campaign is a logical group of coupon codes. For example, "April sale promotion" or "Discount codes". Coupon codes are siloed within a campaign and also only valid, redeemable inside the campaign.
